### PR TITLE
Document libsoup dependency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A GTK4 application and widget framework for the [Singularity Desktop Environment
 - json-glib-1.0 ≥ 1.6
 - libpeas-2 ≥ 2.0
 - libsoup ≥ 3.0
+- gtksourceview-5 ≥ 5.0
 
 ## Build & Install
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A GTK4 application and widget framework for the [Singularity Desktop Environment
 - libgee-0.8 ≥ 0.20
 - json-glib-1.0 ≥ 1.6
 - libpeas-2 ≥ 2.0
+- libsoup ≥ 3.0
 
 ## Build & Install
 


### PR DESCRIPTION
I was compiling and got the following errors, later also gtksourceview-5 
```bash
frida@cofftop:/mnt/Vault/prog/sinty/libsingularity$ meson setup build
The Meson build system
Version: 1.11.1
Source dir: /mnt/Vault/prog/sinty/libsingularity
Build dir: /mnt/Vault/prog/sinty/libsingularity/build
Build type: native build
Project name: libsingularity
Project version: 0.1.0
C compiler for the host machine: cc (gcc 16.1.1 "cc (GCC) 16.1.1 20260515 (Red Hat 16.1.1-2)")
C linker for the host machine: cc ld.bfd 2.46-3
Vala compiler for the host machine: valac (valac 0.56.19)
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program msgfmt found: YES (/usr/bin/msgfmt)
Program msginit found: YES (/usr/bin/msginit)
Program msgmerge found: YES (/usr/bin/msgmerge)
Program xgettext found: YES (/usr/bin/xgettext)
Found pkg-config: YES (/usr/bin/pkg-config) 2.5.1
Run-time dependency gtk4 found: YES 4.22.4
Run-time dependency gtk4-layer-shell-0 found: YES 1.3.0
Run-time dependency gee-0.8 found: YES 0.20.8
Run-time dependency json-glib-1.0 found: YES 1.10.8
Run-time dependency libpeas-2 found: YES 2.2.1
Run-time dependency gmodule-2.0 found: YES 2.88.1
Did not find CMake 'cmake'
Found CMake: NO
Run-time dependency libsoup-3.0 found: NO  (tried pkg-config)

meson.build:24:17: ERROR: Dependency "libsoup-3.0" not found (tried pkg-config)

A full log can be found at /mnt/Vault/prog/sinty/libsingularity/build/meson-logs/meson-log.txt
```