### PR TITLE
Bump `meson_version` to 1.10.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libsingularity', ['vala', 'c'],
   version: '0.1.0',
   license: 'LGPL-2.1-only',
-  meson_version: '>= 0.59.0',
+  meson_version: '>= 1.10.0',
 )
 
 gnome     = import('gnome')


### PR DESCRIPTION
The `vala_gir()` function was introduced in Meson 1.10, which means it is impossible to build the project with GObject introspection on lower versions, especially the previous minimum version of 0.59.0.