### PR TITLE
feat: add a legacy titlebar render path for windows

### DIFF
--- a/src/ui/visual/hover_controls.vala
+++ b/src/ui/visual/hover_controls.vala
@@ -149,7 +149,10 @@ namespace Singularity.Widgets {
                                                          bool with_drag  = true,
                                                          bool with_close = true) {
             if (window is Singularity.Widgets.Window
-                && ((Singularity.Widgets.Window) window).force_ssd) {
+                && (((Singularity.Widgets.Window) window).force_ssd
+                    || ((Singularity.Widgets.Window) window).legacy_titlebar)) {
+                // SSD and the legacy titlebar both want app buttons routed into
+                // the static toolbar instead of a floating bubble bar.
                 var hc = new HoverControls.empty_passthrough ();
                 hc._ssd_bypass        = true;
                 hc._ssd_target_window = window;

--- a/src/ui/windowing/toolbar.vala
+++ b/src/ui/windowing/toolbar.vala
@@ -18,6 +18,12 @@ namespace Singularity.Widgets {
         /** Container on the trailing (right) side of the toolbar. */
         public Box end_box { get; private set; }
 
+        /** The window minimize button in the trailing area (hidden by default). */
+        public Button minimize_btn { get; private set; }
+
+        /** The window maximize button in the trailing area (hidden by default). */
+        public Button maximize_btn { get; private set; }
+
         /** The window close button in the trailing area. */
         public CloseButton close_btn { get; private set; }
 
@@ -57,6 +63,32 @@ namespace Singularity.Widgets {
             end_box.halign = Align.END;
             end_box.set_margin_top(3);
             end_box.set_margin_bottom(3);
+            minimize_btn = new Button.from_icon_name("window-minimize-symbolic");
+            minimize_btn.add_css_class("flat");
+            minimize_btn.add_css_class("image-button");
+            minimize_btn.valign = Align.CENTER;
+            minimize_btn.visible = false;
+            minimize_btn.tooltip_text = _("Minimize Window");
+            minimize_btn.clicked.connect(() => {
+                var w = get_root() as Gtk.Window;
+                if (w != null) w.minimize();
+            });
+            end_box.append(minimize_btn);
+
+            maximize_btn = new Button.from_icon_name("window-maximize-symbolic");
+            maximize_btn.add_css_class("flat");
+            maximize_btn.add_css_class("image-button");
+            maximize_btn.valign = Align.CENTER;
+            maximize_btn.visible = false;
+            maximize_btn.tooltip_text = _("Maximize Window");
+            maximize_btn.clicked.connect(() => {
+                var w = get_root() as Gtk.Window;
+                if (w == null) return;
+                if (w.maximized) w.unmaximize();
+                else w.maximize();
+            });
+            end_box.append(maximize_btn);
+
             close_btn = new Singularity.Widgets.CloseButton();
             close_btn.clicked.connect(() => {
                 var window = (Gtk.Window)get_root();
@@ -74,11 +106,23 @@ namespace Singularity.Widgets {
             add_css_class("toolbar-scroll-under");
         }
 
+        /**
+         * Shows the minimize/maximize controls following the user's window
+         * button-layout. Used by the legacy static titlebar.
+         */
+        public void enable_window_controls() {
+            string layout = Gtk.Settings.get_default().gtk_decoration_layout ?? ":close";
+            minimize_btn.visible = "minimize" in layout;
+            maximize_btn.visible = "maximize" in layout;
+        }
+
         /** Enables or disables server-side-decoration mode on this toolbar. */
         public void set_ssd_mode(bool enabled) {
             if (enabled) {
                 add_css_class("ssd-mode");
                 close_btn.visible = false;
+                minimize_btn.visible = false;
+                maximize_btn.visible = false;
                 is_static = true;
             } else {
                 remove_css_class("ssd-mode");

--- a/src/ui/windowing/window.vala
+++ b/src/ui/windowing/window.vala
@@ -210,6 +210,7 @@ namespace Singularity.Widgets {
                 // App bubbles get redirected into it by HoverControls.
                 toolbar.is_static = true;
                 toolbar.visible = true;
+                toolbar.enable_window_controls();
                 var legacy_handle = new WindowHandle();
                 legacy_handle.set_child(toolbar);
                 legacy_handle.valign = Align.START;

--- a/src/ui/windowing/window.vala
+++ b/src/ui/windowing/window.vala
@@ -130,6 +130,11 @@ namespace Singularity.Widgets {
         /** True when the user has opted into server-side decorations.
             HoverControls reads this to switch to its SSD fallback. */
         public bool force_ssd { get { return _force_ssd; } }
+        private bool _legacy_titlebar = false;
+        /** True when the user prefers the classic static titlebar over the
+            floating hover controls. HoverControls redirects app bubbles into
+            the toolbar (same bypass path as SSD). Ignored while force_ssd is on. */
+        public bool legacy_titlebar { get { return _legacy_titlebar; } }
         private WindowHandle? _flat_drag_handle  = null;
         private Button?       _flat_close_btn    = null;
         private RoundedFrame? _app_frame         = null;
@@ -150,6 +155,9 @@ namespace Singularity.Widgets {
 
             desktop_settings = Singularity.Core.safe_settings(Singularity.Runtime.desktop_settings_schema);
             _force_ssd = desktop_settings != null && desktop_settings.get_boolean("force-ssd");
+            // Legacy titlebar is a CSD mode, so it only applies when SSD is off.
+            _legacy_titlebar = !_force_ssd && desktop_settings != null
+                && desktop_settings.get_boolean("legacy-titlebar");
 
             if (_force_ssd) {
                 add_css_class("ssd-mode");
@@ -196,6 +204,16 @@ namespace Singularity.Widgets {
                 // (SSD bypass) packs buttons into it.
                 toolbar.visible = false;
                 outer_box.append(toolbar);
+            } else if (_legacy_titlebar) {
+                // Classic static titlebar: a real toolbar at the top of the
+                // window flow with its own close button and centred title.
+                // App bubbles get redirected into it by HoverControls.
+                toolbar.is_static = true;
+                toolbar.visible = true;
+                var legacy_handle = new WindowHandle();
+                legacy_handle.set_child(toolbar);
+                legacy_handle.valign = Align.START;
+                outer_box.append(legacy_handle);
             }
 
             main_container = new Box(Orientation.HORIZONTAL, 0);
@@ -228,7 +246,7 @@ namespace Singularity.Widgets {
             content_area.vexpand = true;
             main_container.append(content_area);
 
-            if (!_force_ssd) {
+            if (!_force_ssd && !_legacy_titlebar) {
                 // Regular toolbar overlay (drag handle = toolbar itself)
                 var handle = new WindowHandle();
                 handle.set_child(toolbar);
@@ -399,13 +417,16 @@ namespace Singularity.Widgets {
         // -- Layout / helpers ------------------------------------------
 
         private void _update_flat_mode() {
-            if (_force_ssd) return;
+            // Legacy/SSD keep the toolbar in the box flow and never go flat.
+            if (_force_ssd || _legacy_titlebar) return;
             toolbar.visible = !_flat;
             if (_flat) main_container.margin_top = 0;
         }
 
         private void update_layout() {
-            if (_force_ssd) {
+            // Legacy/SSD toolbars take real layout space, so the content needs
+            // no top margin (only the overlay hover toolbar is pushed down).
+            if (_force_ssd || _legacy_titlebar) {
                 main_container.margin_top = 0;
                 return;
             }


### PR DESCRIPTION
Hey! 👋 This is one piece of a small, opt-in **Legacy Titlebar** feature requested in singularityos-lab/singularity-desktop#29.

### What this PR does
Adds a `legacy_titlebar` mode to `Singularity.Widgets.Window`. When the desktop's `legacy-titlebar` setting is on (and SSD is off), a window renders a **classic static toolbar** at the top of its content flow — real close button + centred title — instead of the floating hover bubble controls.

### How it works
It deliberately **reuses the existing SSD bypass** in `HoverControls`: app buttons are routed into the static `Window.toolbar` rather than a bubble bar. The only differences from SSD are that the window stays **client-side decorated** (so the rounded-corner look is preserved) and the toolbar keeps its **own** close button. No new rendering machinery — it leans on what's already there.

### Notes
- The mode is read at window construction, so switching it needs an app restart (same as the existing SSD toggle).
- `force-ssd` takes precedence by design.
- Default behaviour is completely unchanged when the setting is off.

### Part of a 3-repo set
- 🪟 window render path → **this PR**
- 🎛️ Settings toggle → singularityos-lab/singularity-shell#1
- 🧩 schema key → singularityos-lab/singularity-desktop#31 (closes #29)

Totally happy to adjust the shape if you'd prefer something different (e.g. folding this and `force-ssd` into a single Hover / Legacy / System picker). Thanks so much for taking a look! 🙏
