### PR TITLE
fix: honor buttons-side preference in the classic titlebar

### DIFF
--- a/src/ui/windowing/toolbar.vala
+++ b/src/ui/windowing/toolbar.vala
@@ -125,10 +125,49 @@ namespace Singularity.Widgets {
         }
 
         private void apply_button_layout() {
+            if (has_css_class("ssd-mode")) {
+                minimize_btn.visible = false;
+                maximize_btn.visible = false;
+                close_btn.visible = false;
+                return;
+            }
+
             string layout = resolve_button_layout();
-            minimize_btn.visible = "minimize" in layout;
-            maximize_btn.visible = "maximize" in layout;
-            close_btn.visible = "close" in layout;
+            string[] parts = layout.split(":");
+            string left_str  = parts.length > 0 ? parts[0] : "";
+            string right_str = parts.length > 1 ? parts[1] : "";
+
+            bool close_left  = left_str.contains("close");
+            bool min_left    = left_str.contains("minimize");
+            bool max_left    = left_str.contains("maximize");
+            bool close_right = right_str.contains("close");
+            bool min_right   = right_str.contains("minimize");
+            bool max_right   = right_str.contains("maximize");
+
+            bool cluster_on_left = close_left || (!close_right && (min_left || max_left));
+
+            detach_control(minimize_btn);
+            detach_control(maximize_btn);
+            detach_control(close_btn);
+
+            if (cluster_on_left) {
+                start_box.prepend(minimize_btn);
+                start_box.prepend(maximize_btn);
+                start_box.prepend(close_btn);
+            } else {
+                end_box.append(minimize_btn);
+                end_box.append(maximize_btn);
+                end_box.append(close_btn);
+            }
+
+            minimize_btn.visible = min_left  || min_right;
+            maximize_btn.visible = max_left  || max_right;
+            close_btn.visible    = close_left || close_right;
+        }
+
+        private static void detach_control(Widget w) {
+            var parent = w.get_parent();
+            if (parent is Box) ((Box) parent).remove(w);
         }
 
         // Prefer the host org.gnome.desktop.wm.preferences button-layout (which


### PR DESCRIPTION
The classic (legacy static) titlebar honored the **Buttons Side** setting only for visibility, not placement. `ToolBar.apply_button_layout()` toggled the minimize/maximize/close controls on and off but always left them in the trailing box, so switching Buttons Side to **Left** did nothing — the controls stayed pinned to the right. The floating hover-control path (`HoverControls`) already handled sides correctly, so the two titlebar modes disagreed.

## Fix

- Parse `button-layout` into leading/trailing sides and reparent the controls to the chosen edge, at the extreme leading/trailing position.
- Reuse the exact same cluster-side logic as `HoverControls` (`close_left || (!close_right && (min_left || max_left))`) so both titlebar modes agree.
- Skip reflowing/showing the in-toolbar controls in SSD mode, where the compositor draws the decorations (previously a live layout change could resurrect them).

The parsing mirrors the existing `layout.split(":")` pattern in `hover_controls.vala`, so no new warning class is introduced.

## Testing

- `meson setup build --buildtype=release && ninja -C build` — builds clean (errors: 0).
- Installed locally with **Classic Titlebar** enabled: toggling **Buttons Side** between Left/Right now moves the controls live, and matches the floating hover-control behavior.
- Verified default (`:close`) and SSD mode still behave correctly.