### PR TITLE
feat(system): add SensorMonitor, a generic sysfs temperature/clock backend

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -257,6 +257,16 @@ if get_option('system')
     dependencies: [gio_dep, gee_dep],
   )
   test('hardware-info', hardware_info_test)
+
+  sensor_test = executable(
+    'sensor-test',
+    files(
+      'tests/sensor_test.vala',
+      'src/system/sensor.vala',
+    ),
+    dependencies: [gio_dep, gee_dep],
+  )
+  test('sensor', sensor_test)
 endif
 
 # Build the Singularity GTK3/GTK4 theme for third-party apps. Orchis supplies

--- a/meson.build
+++ b/meson.build
@@ -211,6 +211,7 @@ if get_option('system')
     'src/system/night_light_manager.vala',
     'src/system/autostart_manager.vala',
     'src/system/hardware_info.vala',
+    'src/system/sensor.vala',
   )
 
   libsingularity_system = shared_library('singularity-system',

--- a/src/system/sensor.vala
+++ b/src/system/sensor.vala
@@ -1,0 +1,680 @@
+using GLib;
+
+namespace Singularity {
+
+    public enum SensorKind {
+        CPU,
+        GPU,
+        SYSTEM
+    }
+
+    /** One temperature sensor, as reported by the kernel. */
+    public class SensorReading : Object {
+        public string label { get; private set; }
+        public int millidegrees { get; private set; }
+        public SensorKind kind { get; private set; }
+
+        public SensorReading(string label, int millidegrees, SensorKind kind) {
+            this.label = label;
+            this.millidegrees = millidegrees;
+            this.kind = kind;
+        }
+    }
+
+    /** One power rail, in milliwatts. */
+    public class PowerReading : Object {
+        public string label { get; private set; }
+        public int milliwatts { get; private set; }
+
+        public PowerReading(string label, int milliwatts) {
+            this.label = label;
+            this.milliwatts = milliwatts;
+        }
+    }
+
+    /** One fan, as reported by hwmon. */
+    public class FanReading : Object {
+        public string label { get; private set; }
+        public int rpm { get; private set; }
+
+        public FanReading(string label, int rpm) {
+            this.label = label;
+            this.rpm = rpm;
+        }
+    }
+
+    /**
+     * Reads temperatures, fan speeds and CPU clocks from sysfs.
+     *
+     * SOURCES. /sys/class/hwmon is primary: it is the generic kernel interface
+     * and covers x86 (coretemp, k10temp, zenpower) plus most GPUs (amdgpu,
+     * nouveau, i915). /sys/class/thermal is the fallback, because a number of
+     * ARM SoCs expose temperatures only there.
+     *
+     * CLASSIFICATION IS AN ALLOW-LIST, AND THAT IS THE WHOLE POINT.
+     * An earlier version treated any unrecognised sensor as a CPU sensor. That
+     * is wrong on ordinary hardware, and measurably so -- checked against four
+     * machines, every one of them reported something that was not the CPU:
+     *
+     *   Ryzen 8700G desktop   picked "enp1s0 PHY" 68 C   (a NIC; CPU was 59 C)
+     *   Threadripper          picked "enp1s0 PHY" 80 C   (a NIC; CPU was 67 C)
+     *   Comet Lake laptop     picked "pch_cometlake" 43 C (chipset; CPU 36 C)
+     *   Dell workstation      picked "dell_smm" 85 C     (SMM probe; CPU 47 C)
+     *
+     * An unknown sensor is therefore SYSTEM, never CPU. `cpu_millidegrees` is
+     * -1 unless a sensor was positively identified as a CPU, so a caller can
+     * tell "no CPU sensor here" from "the CPU is cold" instead of confidently
+     * displaying a network chip as the processor temperature.
+     *
+     * SoCs whose zone names no generic list can know (CIX Sky1 uses TZB0/TZB1
+     * for its big cluster and TZGT for graphics) are handled by cpu_hint and
+     * gpu_hint, which a distribution can set without patching this file.
+     *
+     * NVIDIA. Their driver publishes NO hwmon node -- verified on both the
+     * proprietary build (595.58) and the open kernel module (595.71); neither
+     * creates one under /sys/class/hwmon or the DRM device. So NVIDIA GPUs are
+     * queried through nvidia-smi instead, ASYNCHRONOUSLY and only when the
+     * binary is present. Measured cost is 14-16 ms per query on an RTX 4500,
+     * i.e. under 1% duty cycle at the default 2 s interval, and the call never
+     * blocks the caller's thread. libnvidia-ml is also present on such systems,
+     * so this could move to NVML later without a fork; nvidia-smi is chosen
+     * first because it needs no new link-time dependency.
+     *
+     * POWER. Most boards expose no power rail at all (no power*_input,
+     * curr*_input or energy*_uj), so no wattage is invented for them and
+     * gpu_power_milliwatts stays -1. Where the hardware really does report it
+     * -- NVIDIA via nvidia-smi -- it is passed through as measured.
+     */
+    public class SensorMonitor : Object {
+        // Public because start() uses it as a default argument, and Vala requires
+        // a default value to be at least as accessible as the method.
+        public const int DEFAULT_INTERVAL_SEC = 2;
+
+        private const string HWMON_DIR = "/sys/class/hwmon";
+        private const string THERMAL_DIR = "/sys/class/thermal";
+        private const string CPUFREQ_DIR = "/sys/devices/system/cpu/cpufreq";
+
+        // Kernel driver names, not product names.
+        private const string[] CPU_CHIPS = {
+            "coretemp", "k10temp", "zenpower", "x86_pkg_temp",
+            "cpu_thermal", "cpu-thermal", "soc_thermal", "soc-thermal",
+            // Tegra/Thor-class boards name their zones this way.
+            "cpu-therm", "tj-thermal",
+            // Bare "cpu" catches the per-core Qualcomm naming (cpu0_0_thermal,
+            // cpu1_2_thermal, ...) and anything else that spells it out; a
+            // sensor with "cpu" in its name is a CPU sensor in practice.
+            // "cluster" is the CPU cluster zone on those same SoCs.
+            "cpu", "cluster",
+            "armada_thermal", "imx_thermal", "sun4i-ts", "scpi-sensors"
+        };
+        // hwmon label text that identifies a CPU package or core.
+        private const string[] CPU_LABELS = {
+            "package id", "tctl", "tdie", "tccd", "core "
+        };
+        private const string[] GPU_CHIPS = {
+            "amdgpu", "radeon", "nouveau", "i915", "xe",
+            "panfrost", "panthor", "mali", "lima", "v3d", "vc4",
+            // Tegra/Thor expose the integrated GPU as a thermal zone.
+            "gpu-thermal", "gpu-therm",
+            // Bare "gpu" also catches Qualcomm's GPU subsystem zones
+            // (gpuss_0_thermal .. gpuss_7_thermal, Adreno). Checked before the
+            // CPU list, so "gpuss" cannot be mistaken for a CPU sensor.
+            "gpu"
+        };
+
+        private uint _timer_id = 0;
+        private int _interval_sec = DEFAULT_INTERVAL_SEC;
+        private SensorReading[] _readings = {};
+        private int[] _clocks_khz = {};
+        private FanReading[] _fans = {};
+        private PowerReading[] _power = {};
+        private SensorReading[] _nvidia_readings = {};
+        private bool _nvidia_present = false;
+        private bool _nvidia_checked = false;
+        private bool _nvidia_in_flight = false;
+
+        /** Hottest sensor positively identified as a CPU, or -1 if none. */
+        public int cpu_millidegrees { get; private set; default = -1; }
+        /** Hottest sensor identified as a GPU, or -1 if none. */
+        public int gpu_millidegrees { get; private set; default = -1; }
+        /** Hottest sensor that is neither, or -1. Use when there is no CPU. */
+        public int system_millidegrees { get; private set; default = -1; }
+        /** Highest current CPU clock in kHz, or -1 when cpufreq is absent. */
+        public int cpu_khz { get; private set; default = -1; }
+        /** False when the machine exposes nothing readable. */
+        public bool available { get; private set; default = false; }
+        /** GPU power draw where the hardware reports it, else -1. */
+        public int gpu_power_milliwatts { get; private set; default = -1; }
+
+        /**
+         * Substring identifying the CPU/GPU sensor on hardware the allow-list
+         * cannot know. Empty by default: a distribution sets these, and no
+         * single vendor's naming is baked in here.
+         */
+        public string cpu_hint { get; set; default = ""; }
+        public string gpu_hint { get; set; default = ""; }
+
+        public signal void updated();
+
+        public SensorMonitor() {}
+
+        public void start(int interval_sec = DEFAULT_INTERVAL_SEC) {
+            if (_timer_id != 0) return;
+            _interval_sec = interval_sec > 0 ? interval_sec : DEFAULT_INTERVAL_SEC;
+            refresh();
+            _timer_id = Timeout.add_seconds(_interval_sec, () => {
+                refresh();
+                return Source.CONTINUE;
+            });
+        }
+
+        public void stop() {
+            if (_timer_id != 0) {
+                Source.remove(_timer_id);
+                _timer_id = 0;
+            }
+        }
+
+        public override void dispose() {
+            stop();
+            base.dispose();
+        }
+
+        /** Every sensor read on the last refresh, in discovery order. */
+        public SensorReading[] readings() {
+            return _readings;
+        }
+
+        /** Current CPU clocks in kHz, highest first. */
+        public int[] clocks_khz() {
+            return _clocks_khz;
+        }
+
+        /**
+         * Fans that are actually turning.
+         *
+         * Zero-RPM entries are omitted: a board commonly exposes more fan
+         * headers than it has fans, and those read 0 forever. MEASURED on an
+         * IGX Thor dev kit -- f75308 presents four headers of which two are
+         * populated (1342 and 1046 RPM) and two read 0. Listing the empty ones
+         * would imply two dead fans. A genuinely stopped fan is therefore also
+         * hidden, which is the deliberate trade: an absent fan and an idle one
+         * are indistinguishable through this interface.
+         */
+        public FanReading[] fans() {
+            return _fans;
+        }
+
+        /**
+         * Power rails the hardware actually measures.
+         *
+         * Two sources, both real readings rather than estimates:
+         *   * hwmon power*_input, a direct figure in microwatts. An AMD GPU
+         *     reports its package power this way (measured: amdgpu PPT 59.2 W).
+         *   * INA-style shunt monitors, which publish bus voltage and current
+         *     per channel but no power field. Volts x amps on the SAME channel
+         *     is measurement, not synthesis, and it cross-checks: on an IGX
+         *     Thor board channel 1 reads 12.08 V and 140 mA = 1.69 W, which is
+         *     exactly what nvidia-smi independently reports for that GPU.
+         *
+         * DELIBERATELY NOT INCLUDED: Intel RAPL. /sys/class/powercap/.../
+         * energy_uj is root-only on current kernels (restricted after the
+         * Platypus side-channel work), so a desktop session simply cannot read
+         * it -- measured here as an empty value rather than a number. It also
+         * reports cumulative energy, so watts would require differencing over
+         * time. Nothing is reported rather than guessed.
+         */
+        public PowerReading[] power_rails() {
+            return _power;
+        }
+
+        private static string? read_first_line(string path) {
+            string contents;
+            try {
+                if (!FileUtils.get_contents(path, out contents)) {
+                    return null;
+                }
+            } catch (FileError e) {
+                return null;
+            }
+            return contents.strip();
+        }
+
+        private static bool matches_any(string text, string[] needles) {
+            string lower = text.down();
+            foreach (string needle in needles) {
+                if (lower.contains(needle)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private SensorKind classify(string chip, string? label) {
+            string joined = (label != null && label != "")
+                ? chip + " " + label
+                : chip;
+
+            if (gpu_hint != "" && joined.contains(gpu_hint)) {
+                return SensorKind.GPU;
+            }
+            if (cpu_hint != "" && joined.contains(cpu_hint)) {
+                return SensorKind.CPU;
+            }
+            if (matches_any(chip, GPU_CHIPS)) {
+                return SensorKind.GPU;
+            }
+            if (matches_any(chip, CPU_CHIPS)) {
+                return SensorKind.CPU;
+            }
+            if (label != null && matches_any(label, CPU_LABELS)) {
+                return SensorKind.CPU;
+            }
+            // Unknown is SYSTEM on purpose. See the class comment.
+            return SensorKind.SYSTEM;
+        }
+
+        private SensorReading[] collect_hwmon() {
+            SensorReading[] found = {};
+            Dir dir;
+            try {
+                dir = Dir.open(HWMON_DIR, 0);
+            } catch (FileError e) {
+                return found;
+            }
+            string? node;
+            while ((node = dir.read_name()) != null) {
+                string base_path = HWMON_DIR + "/" + node;
+                string chip = read_first_line(base_path + "/name") ?? node;
+                Dir inner;
+                try {
+                    inner = Dir.open(base_path, 0);
+                } catch (FileError e) {
+                    continue;
+                }
+                string? entry;
+                while ((entry = inner.read_name()) != null) {
+                    if (!entry.has_prefix("temp") || !entry.has_suffix("_input")) {
+                        continue;
+                    }
+                    string? raw = read_first_line(base_path + "/" + entry);
+                    if (raw == null) {
+                        continue;
+                    }
+                    int millidegrees = int.parse(raw);
+                    if (millidegrees <= 0) {
+                        continue;
+                    }
+                    string stem = entry.substring(0, entry.length - "_input".length);
+                    string? label = read_first_line(base_path + "/" + stem + "_label");
+                    string name = (label != null && label != "")
+                        ? "%s %s".printf(chip, label)
+                        : chip;
+                    found += new SensorReading(name, millidegrees, classify(chip, label));
+                }
+            }
+            return found;
+        }
+
+        private SensorReading[] collect_thermal() {
+            SensorReading[] found = {};
+            Dir dir;
+            try {
+                dir = Dir.open(THERMAL_DIR, 0);
+            } catch (FileError e) {
+                return found;
+            }
+            string? node;
+            while ((node = dir.read_name()) != null) {
+                if (!node.has_prefix("thermal_zone")) {
+                    continue;
+                }
+                string base_path = THERMAL_DIR + "/" + node;
+                string? zone_type = read_first_line(base_path + "/type");
+                string? raw = read_first_line(base_path + "/temp");
+                if (zone_type == null || raw == null) {
+                    continue;
+                }
+                int millidegrees = int.parse(raw);
+                if (millidegrees <= 0) {
+                    continue;
+                }
+                found += new SensorReading(zone_type, millidegrees, classify(zone_type, null));
+            }
+            return found;
+        }
+
+        private FanReading[] collect_fans() {
+            FanReading[] found = {};
+            Dir dir;
+            try {
+                dir = Dir.open(HWMON_DIR, 0);
+            } catch (FileError e) {
+                return found;
+            }
+            string? node;
+            while ((node = dir.read_name()) != null) {
+                string base_path = HWMON_DIR + "/" + node;
+                string chip = read_first_line(base_path + "/name") ?? node;
+                Dir inner;
+                try {
+                    inner = Dir.open(base_path, 0);
+                } catch (FileError e) {
+                    continue;
+                }
+                string? entry;
+                while ((entry = inner.read_name()) != null) {
+                    if (!entry.has_prefix("fan") || !entry.has_suffix("_input")) {
+                        continue;
+                    }
+                    string? raw = read_first_line(base_path + "/" + entry);
+                    if (raw == null) {
+                        continue;
+                    }
+                    int rpm = int.parse(raw);
+                    if (rpm <= 0) {
+                        continue;
+                    }
+                    string stem = entry.substring(0, entry.length - "_input".length);
+                    string? label = read_first_line(base_path + "/" + stem + "_label");
+                    string name = (label != null && label != "")
+                        ? "%s %s".printf(chip, label)
+                        : "%s %s".printf(chip, stem);
+                    found += new FanReading(name, rpm);
+                }
+            }
+            return found;
+        }
+
+        private PowerReading[] collect_power() {
+            PowerReading[] found = {};
+            Dir dir;
+            try {
+                dir = Dir.open(HWMON_DIR, 0);
+            } catch (FileError e) {
+                return found;
+            }
+            string? node;
+            while ((node = dir.read_name()) != null) {
+                string base_path = HWMON_DIR + "/" + node;
+                string chip = read_first_line(base_path + "/name") ?? node;
+
+                // 1. A direct power reading, in microwatts.
+                Dir inner;
+                try {
+                    inner = Dir.open(base_path, 0);
+                } catch (FileError e) {
+                    continue;
+                }
+                string? entry;
+                while ((entry = inner.read_name()) != null) {
+                    if (!entry.has_prefix("power") || !entry.has_suffix("_input")) {
+                        continue;
+                    }
+                    string? raw = read_first_line(base_path + "/" + entry);
+                    if (raw == null) {
+                        continue;
+                    }
+                    int64 microwatts = int64.parse(raw);
+                    if (microwatts <= 0) {
+                        continue;
+                    }
+                    string stem = entry.substring(0, entry.length - "_input".length);
+                    string? label = read_first_line(base_path + "/" + stem + "_label");
+                    string name = (label != null && label != "")
+                        ? "%s %s".printf(chip, label)
+                        : chip;
+                    found += new PowerReading(name, (int) (microwatts / 1000));
+                }
+
+                // 2. Shunt monitors: bus volts x channel amps. hwmon numbers
+                //    both from 1, so channel N pairs inN_input with currN_input.
+                for (int ch = 1; ch <= 8; ch++) {
+                    string? volt_raw = read_first_line("%s/in%d_input".printf(base_path, ch));
+                    string? curr_raw = read_first_line("%s/curr%d_input".printf(base_path, ch));
+                    if (volt_raw == null || curr_raw == null) {
+                        continue;
+                    }
+                    int millivolts = int.parse(volt_raw);
+                    int milliamps = int.parse(curr_raw);
+                    if (millivolts <= 0 || milliamps <= 0) {
+                        continue;
+                    }
+                    string? label = read_first_line("%s/curr%d_label".printf(base_path, ch));
+                    string name = (label != null && label != "")
+                        ? "%s %s".printf(chip, label)
+                        : "%s ch%d".printf(chip, ch);
+                    found += new PowerReading(name, (millivolts * milliamps) / 1000);
+                }
+            }
+            return found;
+        }
+
+        private int[] collect_clocks() {
+            int[] found = {};
+            Dir dir;
+            try {
+                dir = Dir.open(CPUFREQ_DIR, 0);
+            } catch (FileError e) {
+                // cpufreq is absent on many virtual machines and on some x86
+                // without a scaling driver; /proc/cpuinfo still reports a MHz.
+                string? cpuinfo = read_first_line("/proc/cpuinfo");
+                if (cpuinfo != null) {
+                    foreach (string line in cpuinfo.split("\n")) {
+                        if (!line.down().has_prefix("cpu mhz")) {
+                            continue;
+                        }
+                        string[] parts = line.split(":");
+                        if (parts.length < 2) {
+                            continue;
+                        }
+                        int mhz = (int) double.parse(parts[1].strip());
+                        if (mhz > 0) {
+                            found += mhz * 1000;
+                        }
+                    }
+                }
+                return found;
+            }
+            string? node;
+            while ((node = dir.read_name()) != null) {
+                if (!node.has_prefix("policy")) {
+                    continue;
+                }
+                string? raw = read_first_line(CPUFREQ_DIR + "/" + node + "/scaling_cur_freq");
+                if (raw == null) {
+                    continue;
+                }
+                int khz = int.parse(raw);
+                if (khz > 0) {
+                    found += khz;
+                }
+            }
+            return found;
+        }
+
+
+        /**
+         * True when this machine has an NVIDIA driver and nvidia-smi. Checked
+         * once: the answer cannot change without a driver reload, and probing
+         * every tick would spawn a process just to learn "no".
+         */
+        private bool nvidia_available() {
+            if (_nvidia_checked) {
+                return _nvidia_present;
+            }
+            _nvidia_checked = true;
+            _nvidia_present = FileUtils.test("/proc/driver/nvidia", FileTest.IS_DIR)
+                && Environment.find_program_in_path("nvidia-smi") != null;
+            return _nvidia_present;
+        }
+
+        private void parse_nvidia(string? csv) {
+            SensorReading[] found = {};
+            int power_milliwatts = -1;
+            if (csv == null) {
+                _nvidia_readings = found;
+                gpu_power_milliwatts = -1;
+                return;
+            }
+            foreach (string line in csv.split("\n")) {
+                if (line.strip() == "") {
+                    continue;
+                }
+                string[] fields = line.split(",");
+                if (fields.length < 2) {
+                    continue;
+                }
+                string name = fields[0].strip();
+                int celsius = int.parse(fields[1].strip());
+                if (celsius <= 0) {
+                    continue;
+                }
+                found += new SensorReading(name, celsius * 1000, SensorKind.GPU);
+                if (fields.length >= 4) {
+                    // Fields can read "[N/A]" -- an integrated Thor GPU reports
+                    // no SM clock. double.parse yields 0 there, which the
+                    // guard below discards.
+                    double watts = double.parse(fields[3].strip());
+                    if (watts > 0.0) {
+                        int milliwatts = (int) (watts * 1000.0);
+                        if (milliwatts > power_milliwatts) {
+                            power_milliwatts = milliwatts;
+                        }
+                    }
+                }
+            }
+            _nvidia_readings = found;
+            gpu_power_milliwatts = power_milliwatts;
+        }
+
+        /**
+         * Query nvidia-smi off-thread. Spawned via Subprocess.newv rather than a
+         * shell, and never waited on: the result lands on a later tick, so a
+         * slow or wedged driver cannot stall the UI.
+         */
+        private void refresh_nvidia() {
+            if (!nvidia_available() || _nvidia_in_flight) {
+                return;
+            }
+            string[] argv = {
+                "nvidia-smi",
+                "--query-gpu=name,temperature.gpu,clocks.sm,power.draw",
+                "--format=csv,noheader,nounits"
+            };
+            try {
+                Subprocess proc = new Subprocess.newv(
+                    argv, SubprocessFlags.STDOUT_PIPE | SubprocessFlags.STDERR_SILENCE);
+                _nvidia_in_flight = true;
+                proc.communicate_utf8_async.begin(null, null, (obj, res) => {
+                    string? stdout_text = null;
+                    try {
+                        proc.communicate_utf8_async.end(res, out stdout_text, null);
+                    } catch (Error e) {
+                        stdout_text = null;
+                    }
+                    parse_nvidia(stdout_text);
+                    _nvidia_in_flight = false;
+                });
+            } catch (Error e) {
+                // Driver present but the tool failed: stop asking.
+                _nvidia_present = false;
+                _nvidia_in_flight = false;
+            }
+        }
+
+        /**
+         * Whether two sensor names refer to the same thing.
+         *
+         * Compared with separators and case removed, because the SAME sensor is
+         * routinely spelled differently by the two interfaces. MEASURED on a
+         * Raspberry Pi 5: hwmon calls it "cpu_thermal" and the thermal zone
+         * calls it "cpu-thermal", so an exact comparison listed one 53 C sensor
+         * twice.
+         */
+        private static bool same_sensor(string a, string b) {
+            return a.down().replace("-", "").replace("_", "").replace(" ", "")
+                == b.down().replace("-", "").replace("_", "").replace(" ", "");
+        }
+
+        public void refresh() {
+            // BOTH sources, always -- not hwmon-with-thermal-as-fallback.
+            // MEASURED on an NVIDIA IGX Thor dev kit: hwmon exists there, but
+            // contains only a Super-I/O chip, INA power monitors, the NIC and
+            // the NVMe -- no CPU or GPU temperature at all. The CPU and GPU
+            // live in /sys/class/thermal as cpu-thermal and gpu-thermal. A
+            // "use thermal only when hwmon is empty" rule therefore reported NO
+            // CPU on that machine, because hwmon was non-empty but useless.
+            // Thermal zones that merely duplicate an hwmon chip are dropped.
+            SensorReading[] found = collect_hwmon();
+            foreach (SensorReading zone in collect_thermal()) {
+                bool duplicate = false;
+                foreach (SensorReading existing in found) {
+                    if (same_sensor(existing.label, zone.label)) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if (!duplicate) {
+                    found += zone;
+                }
+            }
+            // NVIDIA readings arrive asynchronously, so this merges whatever the
+            // last query returned rather than waiting for a fresh one.
+            refresh_nvidia();
+            foreach (SensorReading reading in _nvidia_readings) {
+                found += reading;
+            }
+            _readings = found;
+
+            int hottest_cpu = -1;
+            int hottest_gpu = -1;
+            int hottest_system = -1;
+            foreach (SensorReading reading in found) {
+                switch (reading.kind) {
+                    case SensorKind.CPU:
+                        if (reading.millidegrees > hottest_cpu) {
+                            hottest_cpu = reading.millidegrees;
+                        }
+                        break;
+                    case SensorKind.GPU:
+                        if (reading.millidegrees > hottest_gpu) {
+                            hottest_gpu = reading.millidegrees;
+                        }
+                        break;
+                    default:
+                        if (reading.millidegrees > hottest_system) {
+                            hottest_system = reading.millidegrees;
+                        }
+                        break;
+                }
+            }
+
+            _fans = collect_fans();
+            _power = collect_power();
+
+            int[] clocks = collect_clocks();
+            // Highest first, so a caller can take element 0 as "the" clock.
+            if (clocks.length > 1) {
+                for (int i = 0; i < clocks.length; i++) {
+                    for (int j = i + 1; j < clocks.length; j++) {
+                        if (clocks[j] > clocks[i]) {
+                            int swap = clocks[i];
+                            clocks[i] = clocks[j];
+                            clocks[j] = swap;
+                        }
+                    }
+                }
+            }
+            _clocks_khz = clocks;
+
+            cpu_millidegrees = hottest_cpu;
+            gpu_millidegrees = hottest_gpu;
+            system_millidegrees = hottest_system;
+            cpu_khz = clocks.length > 0 ? clocks[0] : -1;
+            available = found.length > 0;
+
+            updated();
+        }
+    }
+}

--- a/src/system/sensor.vala
+++ b/src/system/sensor.vala
@@ -93,6 +93,22 @@ namespace Singularity {
         private const string HWMON_DIR = "/sys/class/hwmon";
         private const string THERMAL_DIR = "/sys/class/thermal";
         private const string CPUFREQ_DIR = "/sys/devices/system/cpu/cpufreq";
+        private const string CPUINFO_PATH = "/proc/cpuinfo";
+
+        /**
+         * Prefix applied to every path this class reads.
+         *
+         * Empty in normal use, so the paths are exactly the ones above. Tests
+         * point it at a fixture tree instead: the classification rules are the
+         * part of this class most likely to be wrong on hardware nobody has to
+         * hand, and they are only testable against synthetic sysfs.
+         */
+        public string sysfs_root { get; set; default = ""; }
+
+        private string hwmon_dir() { return sysfs_root + HWMON_DIR; }
+        private string thermal_dir() { return sysfs_root + THERMAL_DIR; }
+        private string cpufreq_dir() { return sysfs_root + CPUFREQ_DIR; }
+        private string cpuinfo_path() { return sysfs_root + CPUINFO_PATH; }
 
         // Kernel driver names, not product names.
         private const string[] CPU_CHIPS = {
@@ -280,13 +296,13 @@ namespace Singularity {
             SensorReading[] found = {};
             Dir dir;
             try {
-                dir = Dir.open(HWMON_DIR, 0);
+                dir = Dir.open(hwmon_dir(), 0);
             } catch (FileError e) {
                 return found;
             }
             string? node;
             while ((node = dir.read_name()) != null) {
-                string base_path = HWMON_DIR + "/" + node;
+                string base_path = hwmon_dir() + "/" + node;
                 string chip = read_first_line(base_path + "/name") ?? node;
                 Dir inner;
                 try {
@@ -322,7 +338,7 @@ namespace Singularity {
             SensorReading[] found = {};
             Dir dir;
             try {
-                dir = Dir.open(THERMAL_DIR, 0);
+                dir = Dir.open(thermal_dir(), 0);
             } catch (FileError e) {
                 return found;
             }
@@ -331,7 +347,7 @@ namespace Singularity {
                 if (!node.has_prefix("thermal_zone")) {
                     continue;
                 }
-                string base_path = THERMAL_DIR + "/" + node;
+                string base_path = thermal_dir() + "/" + node;
                 string? zone_type = read_first_line(base_path + "/type");
                 string? raw = read_first_line(base_path + "/temp");
                 if (zone_type == null || raw == null) {
@@ -350,13 +366,13 @@ namespace Singularity {
             FanReading[] found = {};
             Dir dir;
             try {
-                dir = Dir.open(HWMON_DIR, 0);
+                dir = Dir.open(hwmon_dir(), 0);
             } catch (FileError e) {
                 return found;
             }
             string? node;
             while ((node = dir.read_name()) != null) {
-                string base_path = HWMON_DIR + "/" + node;
+                string base_path = hwmon_dir() + "/" + node;
                 string chip = read_first_line(base_path + "/name") ?? node;
                 Dir inner;
                 try {
@@ -392,13 +408,13 @@ namespace Singularity {
             PowerReading[] found = {};
             Dir dir;
             try {
-                dir = Dir.open(HWMON_DIR, 0);
+                dir = Dir.open(hwmon_dir(), 0);
             } catch (FileError e) {
                 return found;
             }
             string? node;
             while ((node = dir.read_name()) != null) {
-                string base_path = HWMON_DIR + "/" + node;
+                string base_path = hwmon_dir() + "/" + node;
                 string chip = read_first_line(base_path + "/name") ?? node;
 
                 // 1. A direct power reading, in microwatts.
@@ -473,7 +489,7 @@ namespace Singularity {
          */
         private int[] clocks_from_cpuinfo() {
             int[] found = {};
-            string? cpuinfo = read_first_line("/proc/cpuinfo");
+            string? cpuinfo = read_first_line(cpuinfo_path());
             if (cpuinfo == null) {
                 return found;
             }
@@ -497,7 +513,7 @@ namespace Singularity {
             int[] found = {};
             Dir dir;
             try {
-                dir = Dir.open(CPUFREQ_DIR, 0);
+                dir = Dir.open(cpufreq_dir(), 0);
             } catch (FileError e) {
                 return clocks_from_cpuinfo();
             }
@@ -506,7 +522,7 @@ namespace Singularity {
                 if (!node.has_prefix("policy")) {
                     continue;
                 }
-                string? raw = read_first_line(CPUFREQ_DIR + "/" + node + "/scaling_cur_freq");
+                string? raw = read_first_line(cpufreq_dir() + "/" + node + "/scaling_cur_freq");
                 if (raw == null) {
                     continue;
                 }

--- a/src/system/sensor.vala
+++ b/src/system/sensor.vala
@@ -125,6 +125,8 @@ namespace Singularity {
         private uint _timer_id = 0;
         private int _interval_sec = DEFAULT_INTERVAL_SEC;
         private SensorReading[] _readings = {};
+        // Sysfs-derived readings only, without the NVIDIA set merged in.
+        private SensorReading[] _base_readings = {};
         private int[] _clocks_khz = {};
         private FanReading[] _fans = {};
         private PowerReading[] _power = {};
@@ -406,6 +408,11 @@ namespace Singularity {
                 } catch (FileError e) {
                     continue;
                 }
+                // Channels already covered by a direct powerN_input reading.
+                // Shunt drivers (INA219/ina2xx) expose BOTH that and inN/currN
+                // for one physical rail, so synthesising V x I for such a
+                // channel would report the same rail twice under two labels.
+                bool[] direct_channel = new bool[9];
                 string? entry;
                 while ((entry = inner.read_name()) != null) {
                     if (!entry.has_prefix("power") || !entry.has_suffix("_input")) {
@@ -420,6 +427,10 @@ namespace Singularity {
                         continue;
                     }
                     string stem = entry.substring(0, entry.length - "_input".length);
+                    int direct_ch = int.parse(stem.substring("power".length));
+                    if (direct_ch >= 1 && direct_ch <= 8) {
+                        direct_channel[direct_ch] = true;
+                    }
                     string? label = read_first_line(base_path + "/" + stem + "_label");
                     string name = (label != null && label != "")
                         ? "%s %s".printf(chip, label)
@@ -430,6 +441,9 @@ namespace Singularity {
                 // 2. Shunt monitors: bus volts x channel amps. hwmon numbers
                 //    both from 1, so channel N pairs inN_input with currN_input.
                 for (int ch = 1; ch <= 8; ch++) {
+                    if (direct_channel[ch]) {
+                        continue;
+                    }
                     string? volt_raw = read_first_line("%s/in%d_input".printf(base_path, ch));
                     string? curr_raw = read_first_line("%s/curr%d_input".printf(base_path, ch));
                     if (volt_raw == null || curr_raw == null) {
@@ -450,31 +464,42 @@ namespace Singularity {
             return found;
         }
 
+        /**
+         * CPU MHz as reported by /proc/cpuinfo.
+         *
+         * Used when cpufreq yields nothing -- either because the directory is
+         * absent (common on virtual machines and on x86 with no scaling driver)
+         * or because it exists but is empty / has no readable scaling_cur_freq.
+         */
+        private int[] clocks_from_cpuinfo() {
+            int[] found = {};
+            string? cpuinfo = read_first_line("/proc/cpuinfo");
+            if (cpuinfo == null) {
+                return found;
+            }
+            foreach (string line in cpuinfo.split("\n")) {
+                if (!line.down().has_prefix("cpu mhz")) {
+                    continue;
+                }
+                string[] parts = line.split(":");
+                if (parts.length < 2) {
+                    continue;
+                }
+                int mhz = (int) double.parse(parts[1].strip());
+                if (mhz > 0) {
+                    found += mhz * 1000;
+                }
+            }
+            return found;
+        }
+
         private int[] collect_clocks() {
             int[] found = {};
             Dir dir;
             try {
                 dir = Dir.open(CPUFREQ_DIR, 0);
             } catch (FileError e) {
-                // cpufreq is absent on many virtual machines and on some x86
-                // without a scaling driver; /proc/cpuinfo still reports a MHz.
-                string? cpuinfo = read_first_line("/proc/cpuinfo");
-                if (cpuinfo != null) {
-                    foreach (string line in cpuinfo.split("\n")) {
-                        if (!line.down().has_prefix("cpu mhz")) {
-                            continue;
-                        }
-                        string[] parts = line.split(":");
-                        if (parts.length < 2) {
-                            continue;
-                        }
-                        int mhz = (int) double.parse(parts[1].strip());
-                        if (mhz > 0) {
-                            found += mhz * 1000;
-                        }
-                    }
-                }
-                return found;
+                return clocks_from_cpuinfo();
             }
             string? node;
             while ((node = dir.read_name()) != null) {
@@ -489,6 +514,12 @@ namespace Singularity {
                 if (khz > 0) {
                     found += khz;
                 }
+            }
+            // A present cpufreq directory can still yield nothing: no policy*
+            // entries, or policies whose scaling_cur_freq is unreadable. Fall
+            // back on the same source as the absent-directory case.
+            if (found.length == 0) {
+                return clocks_from_cpuinfo();
             }
             return found;
         }
@@ -575,6 +606,13 @@ namespace Singularity {
                     }
                     parse_nvidia(stdout_text);
                     _nvidia_in_flight = false;
+                    // Publish what just arrived. Without this a one-shot
+                    // refresh() never reports an NVIDIA GPU, and a timer-driven
+                    // caller sees it only on the following tick. This merges the
+                    // cached sysfs readings rather than calling refresh() again,
+                    // so completing a query cannot start another one and does not
+                    // re-walk every hwmon and thermal node.
+                    publish_state();
                 });
             } catch (Error e) {
                 // Driver present but the tool failed: stop asking.
@@ -598,6 +636,10 @@ namespace Singularity {
         }
 
         public void refresh() {
+            refresh_internal(true);
+        }
+
+        private void refresh_internal(bool query_nvidia) {
             // BOTH sources, always -- not hwmon-with-thermal-as-fallback.
             // MEASURED on an NVIDIA IGX Thor dev kit: hwmon exists there, but
             // contains only a Super-I/O chip, INA power monitors, the NIC and
@@ -619,9 +661,49 @@ namespace Singularity {
                     found += zone;
                 }
             }
+            // Keep the sysfs-derived set separate from the NVIDIA set: when the
+            // async query lands, publish_state() can merge the two again without
+            // re-walking every hwmon and thermal node.
+            SensorReading[] base_found = found;
+
             // NVIDIA readings arrive asynchronously, so this merges whatever the
             // last query returned rather than waiting for a fresh one.
-            refresh_nvidia();
+            if (query_nvidia) {
+                refresh_nvidia();
+            }
+            _base_readings = base_found;
+
+            _fans = collect_fans();
+            _power = collect_power();
+
+            int[] clocks = collect_clocks();
+            // Highest first, so a caller can take element 0 as "the" clock.
+            if (clocks.length > 1) {
+                for (int i = 0; i < clocks.length; i++) {
+                    for (int j = i + 1; j < clocks.length; j++) {
+                        if (clocks[j] > clocks[i]) {
+                            int swap = clocks[i];
+                            clocks[i] = clocks[j];
+                            clocks[j] = swap;
+                        }
+                    }
+                }
+            }
+            _clocks_khz = clocks;
+
+            publish_state();
+        }
+
+        /**
+         * Recompute the published properties from the cached reading sets and
+         * emit updated().
+         *
+         * Split out of refresh_internal() so the asynchronous nvidia-smi
+         * callback can publish its result without re-walking every hwmon and
+         * thermal node -- it merges _base_readings with the NVIDIA set instead.
+         */
+        private void publish_state() {
+            SensorReading[] found = _base_readings;
             foreach (SensorReading reading in _nvidia_readings) {
                 found += reading;
             }
@@ -650,29 +732,17 @@ namespace Singularity {
                 }
             }
 
-            _fans = collect_fans();
-            _power = collect_power();
-
-            int[] clocks = collect_clocks();
-            // Highest first, so a caller can take element 0 as "the" clock.
-            if (clocks.length > 1) {
-                for (int i = 0; i < clocks.length; i++) {
-                    for (int j = i + 1; j < clocks.length; j++) {
-                        if (clocks[j] > clocks[i]) {
-                            int swap = clocks[i];
-                            clocks[i] = clocks[j];
-                            clocks[j] = swap;
-                        }
-                    }
-                }
-            }
-            _clocks_khz = clocks;
-
             cpu_millidegrees = hottest_cpu;
             gpu_millidegrees = hottest_gpu;
             system_millidegrees = hottest_system;
-            cpu_khz = clocks.length > 0 ? clocks[0] : -1;
-            available = found.length > 0;
+            cpu_khz = _clocks_khz.length > 0 ? _clocks_khz[0] : -1;
+            // Any readable category counts. A VM or a restricted-hwmon setup
+            // can expose clocks, fans or power rails with no temperature at all;
+            // reporting "nothing readable" there would hide real data.
+            available = found.length > 0
+                || _clocks_khz.length > 0
+                || _fans.length > 0
+                || _power.length > 0;
 
             updated();
         }

--- a/src/system/sensor.vala
+++ b/src/system/sensor.vala
@@ -551,6 +551,14 @@ namespace Singularity {
                 return _nvidia_present;
             }
             _nvidia_checked = true;
+            // A fixture root describes a machine that is not this one, so the
+            // host's NVIDIA stack must not leak into it: nvidia-smi would report
+            // real GPUs on a real NVIDIA box and make the fixture's results
+            // depend on where the tests happen to run.
+            if (sysfs_root != "") {
+                _nvidia_present = false;
+                return _nvidia_present;
+            }
             _nvidia_present = FileUtils.test("/proc/driver/nvidia", FileTest.IS_DIR)
                 && Environment.find_program_in_path("nvidia-smi") != null;
             return _nvidia_present;

--- a/tests/sensor_test.vala
+++ b/tests/sensor_test.vala
@@ -1,0 +1,213 @@
+using GLib;
+
+/*
+ * Fixture tests for SensorMonitor's classification and fallback rules.
+ *
+ * Every case here is a shape that was observed on real hardware and got the
+ * answer wrong at some point. They are written as synthetic sysfs trees because
+ * that is the only way to test eight machines' worth of layouts on one.
+ */
+
+private string fixture_root;
+
+private void write_file(string path, string contents) {
+    string dir = Path.get_dirname(path);
+    assert(DirUtils.create_with_parents(dir, 0755) == 0);
+    try {
+        assert(FileUtils.set_contents(path, contents));
+    } catch (FileError e) {
+        error("fixture write failed: %s", e.message);
+    }
+}
+
+/** Create /sys/class/hwmon/hwmonN with a chip name. */
+private string hwmon_chip(int n, string name) {
+    string dir = Path.build_filename(fixture_root, "sys", "class", "hwmon", "hwmon%d".printf(n));
+    write_file(Path.build_filename(dir, "name"), name + "\n");
+    return dir;
+}
+
+private void hwmon_temp(string chip_dir, int idx, int millidegrees, string? label) {
+    write_file(Path.build_filename(chip_dir, "temp%d_input".printf(idx)),
+               "%d\n".printf(millidegrees));
+    if (label != null) {
+        write_file(Path.build_filename(chip_dir, "temp%d_label".printf(idx)), label + "\n");
+    }
+}
+
+private void thermal_zone(int n, string type, int millidegrees) {
+    string dir = Path.build_filename(fixture_root, "sys", "class", "thermal",
+                                     "thermal_zone%d".printf(n));
+    write_file(Path.build_filename(dir, "type"), type + "\n");
+    write_file(Path.build_filename(dir, "temp"), "%d\n".printf(millidegrees));
+}
+
+private void remove_path(File file) {
+    try {
+        var type = file.query_file_type(FileQueryInfoFlags.NOFOLLOW_SYMLINKS);
+        if (type == FileType.DIRECTORY) {
+            var children = file.enumerate_children(FileAttribute.STANDARD_NAME,
+                                                   FileQueryInfoFlags.NOFOLLOW_SYMLINKS);
+            FileInfo? info;
+            while ((info = children.next_file()) != null) {
+                remove_path(file.get_child(info.get_name()));
+            }
+        }
+        file.delete();
+    } catch (GLib.Error e) {
+        // best effort; the tree lives under /tmp
+    }
+}
+
+private void reset_fixture() {
+    if (fixture_root != null && FileUtils.test(fixture_root, FileTest.EXISTS)) {
+        remove_path(File.new_for_path(fixture_root));
+    }
+    try {
+        fixture_root = DirUtils.make_tmp("singularity-sensor-XXXXXX");
+    } catch (FileError e) {
+        error("cannot create fixture root: %s", e.message);
+    }
+}
+
+private Singularity.SensorMonitor monitor_for_fixture() {
+    var m = new Singularity.SensorMonitor();
+    m.sysfs_root = fixture_root;
+    m.refresh();
+    return m;
+}
+
+/*
+ * A NIC and a chipset sensor must never be reported as the CPU.
+ *
+ * MEASURED: an early version treated any unrecognised sensor as CPU and
+ * displayed "enp1s0 PHY" 68 C on a Ryzen 8700G and "pch_cometlake" on a laptop.
+ */
+private void test_unknown_sensors_are_never_cpu() {
+    reset_fixture();
+    string nic = hwmon_chip(0, "enp1s0");
+    hwmon_temp(nic, 1, 68000, "PHY Temperature");
+    string pch = hwmon_chip(1, "pch_cometlake");
+    hwmon_temp(pch, 1, 43000, null);
+    string cpu = hwmon_chip(2, "k10temp");
+    hwmon_temp(cpu, 1, 59000, "Tctl");
+
+    var m = monitor_for_fixture();
+    assert(m.cpu_millidegrees == 59000);
+}
+
+/*
+ * With no recognised CPU sensor at all, cpu_millidegrees stays -1 rather than
+ * picking the hottest thing in the box.
+ */
+private void test_no_cpu_sensor_reports_minus_one() {
+    reset_fixture();
+    string smm = hwmon_chip(0, "dell_smm");
+    hwmon_temp(smm, 1, 85000, null);
+
+    var m = monitor_for_fixture();
+    assert(m.cpu_millidegrees == -1);
+    assert(m.system_millidegrees == 85000);
+}
+
+/*
+ * hwmon can be non-empty and still contain no CPU or GPU, in which case the
+ * thermal zones must still be read.
+ *
+ * MEASURED on an NVIDIA IGX Thor dev kit: hwmon had Super-I/O, INA rails, the
+ * NIC and the NVMe; cpu-thermal and gpu-thermal were thermal zones. A
+ * hwmon-first-with-fallback design reported no CPU there.
+ */
+private void test_thermal_read_even_when_hwmon_nonempty() {
+    reset_fixture();
+    string sio = hwmon_chip(0, "f75308");
+    hwmon_temp(sio, 1, 30000, null);
+    thermal_zone(0, "cpu-thermal", 42000);
+    thermal_zone(1, "gpu-thermal", 39000);
+
+    var m = monitor_for_fixture();
+    assert(m.cpu_millidegrees == 42000);
+    assert(m.gpu_millidegrees == 39000);
+}
+
+/*
+ * The same sensor spelled two ways is reported once.
+ *
+ * MEASURED on a Raspberry Pi 5: hwmon "cpu_thermal", thermal zone "cpu-thermal".
+ */
+private void test_duplicate_sensor_listed_once() {
+    reset_fixture();
+    string chip = hwmon_chip(0, "cpu_thermal");
+    hwmon_temp(chip, 1, 53000, null);
+    thermal_zone(0, "cpu-thermal", 53000);
+
+    var m = monitor_for_fixture();
+    int cpu_readings = 0;
+    foreach (var r in m.readings()) {
+        if (r.kind == Singularity.SensorKind.CPU) cpu_readings++;
+    }
+    assert(cpu_readings == 1);
+}
+
+/*
+ * A GPU zone whose name starts with "gpu" must not be mistaken for a CPU.
+ *
+ * MEASURED on a Snapdragon SC8280XP: 55 zones, including gpuss_0_thermal for the
+ * Adreno alongside cpu0_0_thermal.
+ */
+private void test_gpuss_is_gpu_not_cpu() {
+    reset_fixture();
+    thermal_zone(0, "cpu5_1_thermal", 42000);
+    thermal_zone(1, "gpuss_3_thermal", 47000);
+
+    var m = monitor_for_fixture();
+    assert(m.cpu_millidegrees == 42000);
+    assert(m.gpu_millidegrees == 47000);
+}
+
+/*
+ * A cpufreq directory that exists but yields nothing must still fall back to
+ * /proc/cpuinfo. The fallback used to live in catch(FileError), so it only ran
+ * when the directory was absent -- an empty one left cpu_khz at -1.
+ */
+private void test_cpufreq_empty_dir_falls_back_to_cpuinfo() {
+    reset_fixture();
+    assert(DirUtils.create_with_parents(
+        Path.build_filename(fixture_root, "sys", "devices", "system", "cpu", "cpufreq"),
+        0755) == 0);
+    write_file(Path.build_filename(fixture_root, "proc", "cpuinfo"),
+               "processor\t: 0\ncpu MHz\t\t: 2000.000\n");
+
+    var m = monitor_for_fixture();
+    assert(m.cpu_khz == 2000000);
+}
+
+/*
+ * available means "something readable", not "a temperature was readable". A VM
+ * or restricted-hwmon setup can expose only a fan.
+ */
+private void test_available_with_fan_but_no_temperature() {
+    reset_fixture();
+    string chip = hwmon_chip(0, "some_fan_controller");
+    write_file(Path.build_filename(chip, "fan1_input"), "1200\n");
+
+    var m = monitor_for_fixture();
+    assert(m.cpu_millidegrees == -1);
+    assert(m.available);
+}
+
+public int main(string[] args) {
+    Test.init(ref args);
+    Test.add_func("/sensor/unknown-never-cpu", test_unknown_sensors_are_never_cpu);
+    Test.add_func("/sensor/no-cpu-is-minus-one", test_no_cpu_sensor_reports_minus_one);
+    Test.add_func("/sensor/thermal-when-hwmon-nonempty", test_thermal_read_even_when_hwmon_nonempty);
+    Test.add_func("/sensor/duplicate-listed-once", test_duplicate_sensor_listed_once);
+    Test.add_func("/sensor/gpuss-is-gpu", test_gpuss_is_gpu_not_cpu);
+    Test.add_func("/sensor/cpufreq-empty-falls-back", test_cpufreq_empty_dir_falls_back_to_cpuinfo);
+    Test.add_func("/sensor/available-with-fan-only", test_available_with_fan_but_no_temperature);
+    int rc = Test.run();
+    if (fixture_root != null && FileUtils.test(fixture_root, FileTest.EXISTS)) {
+        remove_path(File.new_for_path(fixture_root));
+    }
+    return rc;
+}


### PR DESCRIPTION
Implements the backend half of singularityos-lab/singularity-desktop#236, following your guidance there:

> let's keep the sensor work generic and expose hardware data trough libsingularity-system, then the shell can consume it without knowing about a specific board

That is what this is: a headless `SensorMonitor` in `libsingularity-system` with no GTK and no board-specific code. A separate shell PR will consume it; this one is standalone and useful on its own.

## Shape

Follows `ResourceMonitor`: `start()`/`stop()`, timer cancelled in `dispose()`, properties plus an `updated` signal.

Properties: `cpu_millidegrees`, `gpu_millidegrees`, `system_millidegrees`, `cpu_khz`, `gpu_power_milliwatts`, `available`, plus `readings()`, `clocks_khz()` and `fans()` for detail UI.

`-1` means "no sensor of this kind was positively identified", which a caller can distinguish from "the CPU is cold".

## The design decision that matters: classification is an allow-list

My first version treated any unrecognised sensor as a CPU sensor. It looked correct on the board I wrote it on and was wrong on every other machine I tried:

| Machine | It displayed | Actually the CPU |
|---|---|---|
| Ryzen 8700G desktop | `enp1s0 PHY` 68 °C — a NIC | `k10temp Tctl` 59 °C |
| Threadripper | `enp1s0 PHY` 80 °C — a NIC | `k10temp Tctl` 67 °C |
| Comet Lake laptop | `pch_cometlake` 43 °C — chipset | `coretemp Package id 0` 36 °C |
| Dell workstation | `dell_smm` 85 °C — an SMM probe | `coretemp Package id 0` 47 °C |

Each is a confident, plausible number that is not the processor, and the Dell one would show an alarming 85 °C for nothing. So known CPU drivers and labels are CPU, known GPU drivers are GPU, and **anything unrecognised is `SYSTEM`, never CPU**.

## Why it reads both hwmon and thermal every cycle

An earlier version read `hwmon` first and only fell back to `/sys/class/thermal` when hwmon came back empty. That breaks on Tegra-class hardware: an NVIDIA IGX Thor dev kit exposes plenty of hwmon (`f75308` Super-I/O, `ina219`/`ina3221` rails, `mlx5`, `nvme`, `pwm_tach`) and **not one of them is a CPU or GPU temperature** — those live in `/sys/class/thermal` as `cpu-thermal`/`gpu-thermal`. hwmon was non-empty but useless, the fallback never fired, and the widget reported no CPU at all.

It now reads both sources every cycle and drops thermal zones that merely duplicate an hwmon chip. A Raspberry Pi 5 exposed the duplicate case: hwmon calls its sensor `cpu_thermal` while the thermal zone calls it `cpu-thermal`, so the same 53 °C appeared twice. Duplicate detection compares with case and separators stripped.

## Board specifics stay out of the library

SoCs whose zone names no generic list can know are handled with `cpu_hint`/`gpu_hint` properties rather than by hardcoding a vendor — a distribution sets them without patching the file. Downstream I set `TZ`/`TZGT` for a CIX Sky1 board's `TZB0`/`TZB1`/`TZM0`/`TZM1` cluster zones. Nothing about Sky1, or any other board, appears in this file.

Qualcomm needed the generic matcher widened rather than special-cased: a Radxa Dragon Q8B (SC8280XP) exposes **55 thermal zones** named `cpu0_0_thermal … cpu7_1_thermal`, `cluster0_thermal`, and `gpuss_0_thermal … gpuss_7_thermal` for the Adreno. Matching bare `cpu`/`cluster`/`gpu` (GPU checked first so `gpuss` cannot be mistaken for a CPU) covers it with no vendor branch.

## NVIDIA

NVIDIA's driver publishes no hwmon node at all — confirmed on both flavours (RTX 4500 Ada, proprietary 595.58.03; RTX 2060 Mobile, open kernel module 595.71.05). Neither creates an entry under `/sys/class/hwmon` or the DRM device, so a pure-sysfs backend cannot see them.

`nvidia-smi` reports it, and it is cheap enough to use — I measured **14–16 ms per query** (5 runs, RTX 4500), under 1% duty cycle at the default 2 s interval. It is implemented as an **optional, asynchronous** path:

- probed **once** (`/proc/driver/nvidia` exists *and* `nvidia-smi` on `PATH`) — no process spawned per tick to learn "no";
- spawned with `Subprocess.newv`, not a shell, per CONTRIBUTING;
- `communicate_utf8_async`, never waited on, so a wedged driver cannot stall a caller — results land on a later tick;
- one query covers all GPUs; if the tool fails, it stops asking.

This is the one piece I would understand you wanting dropped, since it puts a subprocess in `libsingularity-system`. It is self-contained and cleanly separable — say the word and I will remove it or put it behind a build option.

## Power

Reported only where the hardware genuinely measures it (`power*_input`, or INA rails via V×I). Never synthesised — boards with no power rail report `-1` rather than an invented estimate.

## Coverage measured on eight platforms

| Machine | CPU reported | GPU reported |
|---|---|---|
| NVIDIA IGX Thor dev kit (aarch64) | 42 °C `tj-thermal` | `gpu-thermal` + Thor + RTX PRO 6000 |
| Threadripper + RTX 4500 | 68 °C `k10temp Tctl` | RTX 4500 via `nvidia-smi` |
| Comet Lake + RTX 2060 | 38 °C `coretemp Package id 0` | RTX 2060 via `nvidia-smi` |
| Ryzen 8700G (AMD iGPU) | 61 °C `k10temp Tctl` | `amdgpu edge` 40 °C |
| Snapdragon SC8280XP | 42 °C `cpu5_1_thermal` | `gpuss_*` (Adreno) |
| Intel Mac (Coffee Lake + AMD dGPU) | 43 °C `coretemp Package id 0` | `amdgpu edge` + `junction` |
| Raspberry Pi 5 | 53 °C `cpu_thermal` | none (no separate sensor) |
| CIX Sky1 (ARM SoC) | ~50 °C cluster zone | `TZGT` graphics zone |

Before the changes above, three of these displayed a NIC or the chipset as the processor and two reported no CPU at all.

Intel **integrated** GPUs intentionally get no GPU row — checked `i915` on CometLake-H GT2, RocketLake-S GT1 and Raptor Lake-P, and none exposes a GPU temperature. That is correct rather than a gap: on integrated parts the GPU shares the CPU die, so its temperature *is* `coretemp Package id 0`, and a separate row would duplicate the CPU reading under another name. Intel **discrete** (Arc/Xe) should match the existing `i915`/`xe` hwmon names, but I have no card, so that path is **untested** — I would rather say so than imply coverage.

The general lesson, and why the comments in the file are as detailed as they are: **sensor naming has no cross-platform convention.** The zone count ranges from 1 to 55, the same sensor can be spelled two ways on one machine, and a machine can expose plenty of hwmon while none of it is the CPU. Anything that assumes a shape is wrong on somebody's hardware.

## Validation

Clean `meson setup` + full `ninja` from scratch, Debian testing aarch64, valac 0.56.19, GTK 4.22.4:

```
[110/122] Linking target libsingularity-system.so.0.1.0
[122/122] Linking target libsingularity.so.0.1.0

=== exported SensorMonitor symbols ===
  symbol count: 20
singularity_sensor_monitor_clocks_khz
singularity_sensor_monitor_construct
singularity_sensor_monitor_fans
singularity_sensor_monitor_get_available
singularity_sensor_monitor_get_cpu_hint
singularity_sensor_monitor_get_cpu_khz
singularity_sensor_monitor_get_cpu_millidegrees
singularity_sensor_monitor_get_gpu_hint
singularity_sensor_monitor_get_gpu_millidegrees
singularity_sensor_monitor_get_gpu_power_milliwatts
singularity_sensor_monitor_get_system_millidegrees
singularity_sensor_monitor_get_type
```

So the class builds into `libsingularity-system` and is exported for the shell to consume without linking anything new.

Running in daily use on a Sky1 arm64 box (Debian, labwc). Every number in the tables above was read off the named machine, not inferred from documentation.

## Tests

`tests/sensor_test.vala` covers the classification and fallback rules, seven cases, each a shape observed on real hardware that this code got wrong at some point:

- a NIC and a chipset sensor are never reported as the CPU
- no recognised CPU sensor reports `-1` rather than the hottest thing present
- thermal zones are read even when hwmon is non-empty but has no CPU/GPU (the IGX Thor layout)
- the same sensor spelled `cpu_thermal` and `cpu-thermal` is listed once (Pi 5)
- a `gpuss_*` zone is a GPU, not a CPU (Snapdragon SC8280XP)
- a cpufreq directory that exists but yields nothing falls back to `/proc/cpuinfo`
- `available` is true when only a fan is readable

Testing these needs synthetic sysfs, so `SensorMonitor` gains a `sysfs_root` property that prefixes every path it reads. It defaults to `""`, leaving normal behaviour byte-identical; only the tests set it. The NVIDIA probe is skipped when a fixture root is set, so a host with a real NVIDIA GPU cannot leak readings into a synthetic tree and make results machine-dependent.

`meson test` — 7/7 pass. Confirmed the suite is not vacuous by mutation: removing the empty-cpufreq fallback fails exactly the fallback test, and weakening `same_sensor()` to an exact compare fails exactly the duplicate test; both green again after reverting.
